### PR TITLE
Fixing race condition in test

### DIFF
--- a/jobpool/job_pool_test.go
+++ b/jobpool/job_pool_test.go
@@ -1,6 +1,7 @@
 package jobpool
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,8 +10,11 @@ import (
 func Test_JobPool(t *testing.T) {
 	t.Run("100 Jobs runs 100 Jobs", func(t *testing.T) {
 		count := 0
+		var mu sync.Mutex
 		action := func() error {
+			mu.Lock()
 			count++
+			mu.Unlock()
 			return nil
 		}
 		errHandler := func(err error) {}


### PR DESCRIPTION
The shared data across the test action led to a very narrow race condition which could be found with repeated test runs